### PR TITLE
Upgrade client app to React 18

### DIFF
--- a/client/source/package.json
+++ b/client/source/package.json
@@ -9,9 +9,9 @@
     "mobx-react-lite": "^3.2.2",
     "mobx-utils": "^6.0.4",
     "rc-slider": "^9.7.5",
-    "react": "^17.0.2",
+    "react": "^18.1.0",
     "react-color": "^2.19.3",
-    "react-dom": "^17.0.2",
+    "react-dom": "^18.1.0",
     "react-router-dom": "^6.2.1",
     "styled-components": "^5.3.3"
   },
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@types/node": "^12.0.0",
-    "@types/react": "^17.0.0",
+    "@types/react": "^18.0.11",
     "@types/react-color": "^3.0.4",
-    "@types/react-dom": "^17.0.0",
+    "@types/react-dom": "^18.0.5",
     "@types/styled-components": "^5.1.18",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/client/source/src/hooks/useRemoteWorkspaceStores.tsx
+++ b/client/source/src/hooks/useRemoteWorkspaceStores.tsx
@@ -20,7 +20,7 @@ const useRemoteWorkspaceStores = (): RemoteWorkspaceStoresContext => {
   return context;
 };
 
-const RemoteWorkspaceStoresProvider: React.FC = ({ children }) => {
+const RemoteWorkspaceStoresProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [remoteWorkspaceState] = useState<RemoteWorkspaceState>(new RemoteWorkspaceState());
 
   const value: RemoteWorkspaceStoresContext = {

--- a/client/source/src/hooks/useWorkspaceStores.tsx
+++ b/client/source/src/hooks/useWorkspaceStores.tsx
@@ -24,6 +24,7 @@ type Props = {
   backgroundColor: Color;
   initialPenSize?: number;
   initialPenColor?: string;
+  children?: React.ReactNode;
 };
 
 const WorkspaceStoresProvider: React.FC<Props> = (props) => {

--- a/client/source/src/index.tsx
+++ b/client/source/src/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { App } from 'panels';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root')!);
+
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );

--- a/client/source/src/panels/Whiteboard.tsx
+++ b/client/source/src/panels/Whiteboard.tsx
@@ -37,8 +37,8 @@ const Whiteboard: React.FC<Props> = observer(({ inputBus, outputBus }) => {
   const drawing = useRef<boolean>(false);
   const currentPoint = useRef<Point>({ X: 0, Y: 0 });
 
-  const setupCanvasNode = useCallback((node) => setCanvas(node), []);
-  const setupContainerNode = useCallback((node) => setContainer(node), []);
+  const setupCanvasNode = useCallback((node: HTMLCanvasElement | null) => setCanvas(node), []);
+  const setupContainerNode = useCallback((node: HTMLDivElement | null) => setContainer(node), []);
 
   const setFocus = useCallback(
     () => workspaceState.setFocus(FocusTarget.Whiteboard),

--- a/client/source/src/services/windowEvents.tsx
+++ b/client/source/src/services/windowEvents.tsx
@@ -16,7 +16,7 @@ const useWindowEvents = (): WindowEventsContext => {
   return context;
 };
 
-const WindowEventsProvider: React.FC = ({ children }) => {
+const WindowEventsProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [resize, setResize] = useState<number>(1);
 
   const onWindowResize = useCallback(() => setResize((previousValue) => previousValue + 1), []);

--- a/client/source/yarn.lock
+++ b/client/source/yarn.lock
@@ -1762,17 +1762,26 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@^17.0.0":
-  version "17.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
-  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+"@types/react-dom@^18.0.5":
+  version "18.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
+  integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
+"@types/react@*":
   version "17.0.37"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
   integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.0.11":
+  version "18.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.11.tgz#94c9b62020caff17d117374d724de853ec711d21"
+  integrity sha512-JxSwm54IgMW4XTR+zFF5QpNx4JITmFbB4WHR2J0vg9RpjNeyqEMlODXsD2e64br6GX70TL0UYjZJETpyyC1WdA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -7611,7 +7620,7 @@ nwsapi@^2.2.0:
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -9155,14 +9164,13 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.1.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
+  integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.22.0"
 
 react-error-overlay@^6.0.9:
   version "6.0.10"
@@ -9265,13 +9273,12 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.1.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
+  integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -9732,13 +9739,12 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.22.0.tgz#83a5d63594edf074add9a7198b1bae76c3db01b8"
+  integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^1.0.0:
   version "1.0.0"

--- a/client/source/yarn.lock
+++ b/client/source/yarn.lock
@@ -1769,16 +1769,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.37"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
-  integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.0.11":
+"@types/react@*", "@types/react@^18.0.11":
   version "18.0.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.11.tgz#94c9b62020caff17d117374d724de853ec711d21"
   integrity sha512-JxSwm54IgMW4XTR+zFF5QpNx4JITmFbB4WHR2J0vg9RpjNeyqEMlODXsD2e64br6GX70TL0UYjZJETpyyC1WdA==


### PR DESCRIPTION
Issues during upgrade:
- Incompatible versions of `@types/react` where installed because of `react-color` (react/issues/24304#issuecomment-1094565891)
- `React.FC` no longer declares `children` property
- `findDOMNode` is deprecated in StrictMode now
- Compilation errors because of implicit `any` type